### PR TITLE
🔧 レコメンド機能の修正

### DIFF
--- a/app/javascript/recommend_maps.js
+++ b/app/javascript/recommend_maps.js
@@ -143,7 +143,7 @@ window.initMap = function (latitude, longitude, mapElementId = "map") {
     position: location,
     map: map,
     title: "現在地",
-    icon: { url: "http://maps.google.com/mapfiles/ms/icons/blue-dot.png" },
+    icon: { url: "https://maps.google.com/mapfiles/ms/icons/blue-dot.png" },
   });
 
   map.addListener("center_changed", () => {


### PR DESCRIPTION
initMap関数の、new google.maps.Markerの現在地取得のためのURLをhttp://からhttps://に変更しました。