### PR TITLE
🔧 TOPページレイアウト変更・会員登録バリデーション追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
   before_action :set_prefectures, only: %i[new create]
+  before_action :require_no_login, only: [:new, :create]
   skip_before_action :require_login, only: %i[new create]
+
 
   def new
     @user = User.new
@@ -27,5 +29,9 @@ class UsersController < ApplicationController
 
   def set_prefectures
     @prefectures = Prefecture.all
+  end
+
+  def require_no_login
+    redirect_to main_top_path if logged_in?
   end
 end

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -13,9 +13,9 @@
             <div class="lg:w-4/5 mx-auto flex flex-wrap justify-center">
               <div class="lg:w-1/2 w-full lg:pl-10 lg:py-8 mt-8 lg:mt-0 order-last lg:order-first flex flex-col justify-center">
                 <h2 class="text-sm tracking-widest"></h2>
-                <p class="text-sm">秘密にしておきたいけど、人に自慢したい景色！</p>
-                <p class="text-sm">この街に来るのなら、この店の料理は外せへん！</p>
-                <p class="text-sm">旅行で訪れたこの場所、めっちゃ素敵やったわ〜</p>
+                <p class="text-sm whitespace-nowrap">秘密にしておきたいけど、人に自慢したい景色！</p>
+                <p class="text-sm whitespace-nowrap">この街に来るのなら、この店の料理は外せへん！</p>
+                <p class="text-sm whitespace-nowrap">旅行で訪れたこの場所、めっちゃ素敵やったわ〜</p>
                 <p class="leading-relaxed text-lg lg:text-2xl font-bold">そんな関西のめっちゃええとこを、</p>
                 <p class="leading-relaxed text-lg lg:text-2xl font-bold">みんなで共有しあうサービスやで。</p>
               </div>
@@ -46,9 +46,9 @@
           <div class="container px-5 pt-16 pb-20 mx-auto">
             <div class="lg:w-4/5 mx-auto flex flex-wrap">
               <div class="lg:w-1/2 w-full lg:pl-10 lg:py-6 mt-6 lg:mt-0 order-last lg:order-first flex flex-col justify-center">
-              <p class="text-sm">現地の人がおすすめするスポットにハズレなし！</p>
-              <p class="text-sm">関西に訪れた人がおすすめするスポットも知れるわ！</p>
-              <p class="text-sm">しかもGoogle上の評価も一緒に確認できんねん!</p>
+              <p class="text-sm whitespace-nowrap">現地の人がおすすめするスポットにハズレなし！</p>
+              <p class="text-sm whitespace-nowrap">関西に訪れた人がおすすめするスポットも知れるわ！</p>
+              <p class="text-sm whitespace-nowrap">しかもGoogle上の評価も一緒に確認できんねん!</p>
                 <p class="leading-relaxed text-lg lg:text-2xl font-bold">関西で旅行・外食・お出かけプランの</p>
                 <p class="leading-relaxed text-lg lg:text-2xl font-bold">参考にしてみてな。</p>
               </div>


### PR DESCRIPTION
TOPページの文言をsmサイズ時に折り返さないように'whitespace-nowrap'を追加しました。
セキュリティとユーザーエクスペリエンス向上のため、ログイン状態時に会員登録ページにアクセスした場合、メインページにリダイレクトするように設定しました。
